### PR TITLE
csv output format added '-csv'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
              [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]
              [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]
              [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]
-             [-rp privkey partialkeyfile] [prefix]
+             [-rp privkey partialkeyfile] [-csv] [prefix]
 
  prefix: prefix to search (Can contains wildcard '?' or '*')
  -v: Print version
@@ -55,6 +55,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
  -rp privkey partialkeyfile: Reconstruct final private key(s) from partial key(s) info.
  -sp startPubKey: Start the search with a pubKey (for private key splitting)
  -r rekey: Rekey interval in MegaKey, default is disabled
+ -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]
 ```
  
 Exemple (Windows, Intel Core i7-4770 3.4GHz 8 multithreaded cores, GeForce GTX 1050 Ti):
@@ -228,4 +229,3 @@ Priv (HEX): 0x398E7271AF3E5A78821C1ADFDE3EE90760A6B65F72D856CFE455B1264350BCE8
 # License
 
 VanitySearch is licensed under GPLv3.
-

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@ void printUsage() {
   printf("             [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]\n");
   printf("             [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]\n");
   printf("             [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]\n");
-  printf("             [-rp privkey partialkeyfile] [prefix]\n\n");
+  printf("             [-rp privkey partialkeyfile] [-csv] [prefix]\n\n");
   printf(" prefix: prefix to search (Can contains wildcard '?' or '*')\n");
   printf(" -v: Print version\n");
   printf(" -u: Search uncompressed addresses\n");
@@ -60,6 +60,7 @@ void printUsage() {
   printf(" -rp privkey partialkeyfile: Reconstruct final private key(s) from partial key(s) info.\n");
   printf(" -sp startPubKey: Start the search with a pubKey (for private key splitting)\n");
   printf(" -r rekey: Rekey interval in MegaKey, default is disabled\n");
+  printf(" -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]\n");
   exit(-1);
 
 }
@@ -397,6 +398,7 @@ int main(int argc, char* argv[]) {
   startPuKey.Clear();
   bool startPubKeyCompressed;
   bool caseSensitive = true;
+  bool csv = false;
   bool paranoiacSeed = false;
 
   while (a < argc) {
@@ -413,6 +415,9 @@ int main(int argc, char* argv[]) {
       a++;
     } else if (strcmp(argv[a], "-c") == 0) {
       caseSensitive = false;
+      a++;
+    } else if (strcmp(argv[a], "-csv") == 0) {
+      csv = true;
       a++;
     } else if (strcmp(argv[a], "-v") == 0) {
       printf("%s\n",RELEASE);
@@ -534,7 +539,7 @@ int main(int argc, char* argv[]) {
   }
 
   VanitySearch *v = new VanitySearch(secp, prefix, seed, searchMode, gpuEnable, stop, outputFile, sse,
-    maxFound, rekey, caseSensitive, startPuKey, paranoiacSeed);
+    maxFound, rekey, caseSensitive, csv, startPuKey, paranoiacSeed);
   v->Search(nbCPUThread,gpuId,gridSize);
 
   return 0;


### PR DESCRIPTION
csv output format added '-csv'
-csv: Output of matches in csv format as [format],[Address],[WIF],[HEX] in terminal and in output file.

and can you please make 695 and 719 lines in Vanity.cpp file to show pattern of match by replacing addr.c_str() with pattern tags. am unable to do.
fprintf(f, "Pattern  : %s\n", addr.c_str());
if you do this result should be: [pattern] [format],[Address],[WIF],[HEX]
1feee,p2pkh,1feeeH4Ku5P8XKW2zpr2RJgtpAL45GQ3P,L2yDGwGoXgg7aJDQJxch4zAXtRtHKYk7V1mi3ES2Egqp7Vmx8Dp7,AB90DABC088D1C888A6A639870E3A192C3AF7E3BDEEC6923291A08B22738054E

Thanks.