### PR TITLE
csv output format added '-csv' and '-hex' only output added

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
              [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]
              [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]
              [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]
-             [-rp privkey partialkeyfile] [prefix]
+             [-rp privkey partialkeyfile] [-csv] [prefix]
 
  prefix: prefix to search (Can contains wildcard '?' or '*')
  -v: Print version
@@ -55,6 +55,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
  -rp privkey partialkeyfile: Reconstruct final private key(s) from partial key(s) info.
  -sp startPubKey: Start the search with a pubKey (for private key splitting)
  -r rekey: Rekey interval in MegaKey, default is disabled
+ -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]
 ```
  
 Exemple (Windows, Intel Core i7-4770 3.4GHz 8 multithreaded cores, GeForce GTX 1050 Ti):
@@ -228,4 +229,3 @@ Priv (HEX): 0x398E7271AF3E5A78821C1ADFDE3EE90760A6B65F72D856CFE455B1264350BCE8
 # License
 
 VanitySearch is licensed under GPLv3.
-

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
              [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]
              [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]
              [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]
-             [-rp privkey partialkeyfile] [-csv] [prefix]
+             [-rp privkey partialkeyfile] [-csv] [-hex] [prefix]
 
  prefix: prefix to search (Can contains wildcard '?' or '*')
  -v: Print version
@@ -56,6 +56,7 @@ VanitySeacrh [-check] [-v] [-u] [-b] [-c] [-gpu] [-stop] [-i inputfile]
  -sp startPubKey: Start the search with a pubKey (for private key splitting)
  -r rekey: Rekey interval in MegaKey, default is disabled
  -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]
+ -hex: Output of matches in hex only format
 ```
  
 Exemple (Windows, Intel Core i7-4770 3.4GHz 8 multithreaded cores, GeForce GTX 1050 Ti):

--- a/Vanity.cpp
+++ b/Vanity.cpp
@@ -40,7 +40,7 @@ Point _2Gn;
 
 VanitySearch::VanitySearch(Secp256K1 *secp, vector<std::string> &inputPrefixes,string seed,int searchMode, 
                            bool useGpu, bool stop, string outputFile, bool useSSE, uint32_t maxFound,
-                           uint64_t rekey, bool caseSensitive, bool csv, Point &startPubKey, bool paranoiacSeed)
+                           uint64_t rekey, bool caseSensitive, bool csv, bool hex, Point &startPubKey, bool paranoiacSeed)
   :inputPrefixes(inputPrefixes) {
 
   this->secp = secp;
@@ -57,6 +57,7 @@ VanitySearch::VanitySearch(Secp256K1 *secp, vector<std::string> &inputPrefixes,s
   this->hasPattern = false;
   this->caseSensitive = caseSensitive;
   this->csv = csv;
+  this->hex = hex;
   this->startPubKeySpecified = !startPubKey.isZero();
 
   lastRekey = 0;
@@ -692,7 +693,17 @@ void VanitySearch::output(string addr,string pAddr,string pAddrHex) {
     printf("\r");
 if(csv)
 {
-  //  fprintf(f, "%s,", addr.c_str());
+ //  fprintf(f, "%s,", addr.c_str()); //replace with pattern tag
+if(hex)
+{
+  fprintf(f, "%s,", addr.c_str());
+  if (startPubKeySpecified) {
+  fprintf(f, "PartialPriv,%s,", addr.c_str());
+  }
+   fprintf(f, "%s\n", pAddrHex.c_str());
+}
+else
+{
   if (startPubKeySpecified) {
   fprintf(f, "PartialPriv,%s,", addr.c_str());
   fprintf(f, "%s,", pAddr.c_str());
@@ -712,13 +723,22 @@ if(csv)
       break;
     }
       fprintf(f, "%s\n", pAddrHex.c_str());
-
+   }
   }
 }
-else{
-//  fprintf(f, "Pattern  : %s\n", addr.c_str());
-  fprintf(f, "Address  : %s\n", addr.c_str());
-
+else
+{
+//  fprintf(f, "Pattern  : %s\n", addr.c_str()); //replace with pattern tag
+    fprintf(f, "Address  : %s\n", addr.c_str());
+if(hex)
+{
+  if (startPubKeySpecified) {
+  fprintf(f, "PartialPriv: %s\n", pAddr.c_str());
+  }
+    fprintf(f, "Priv(HEX): 0x%s\n", pAddrHex.c_str());
+}
+else
+{
   if (startPubKeySpecified) {
 
   fprintf(f, "PartialPriv: %s\n", pAddr.c_str());
@@ -737,7 +757,7 @@ else{
       break;
     }
       fprintf(f, "Priv(HEX): 0x%s\n", pAddrHex.c_str());
-
+   }
   }
 }
   if(needToClose)

--- a/Vanity.h
+++ b/Vanity.h
@@ -71,7 +71,7 @@ public:
 
   VanitySearch(Secp256K1 *secp, std::vector<std::string> &prefix, std::string seed, int searchMode, 
                bool useGpu,bool stop,std::string outputFile, bool useSSE,uint32_t maxFound,uint64_t rekey,
-               bool caseSensitive,Point &startPubKey,bool paranoiacSeed);
+               bool caseSensitive, bool csv, bool hex, Point &startPubKey,bool paranoiacSeed);
 
   void Search(int nbThread,std::vector<int> gpuId,std::vector<int> gridSize);
   void FindKeyCPU(TH_PARAM *p);
@@ -114,6 +114,8 @@ private:
   int searchMode;
   bool hasPattern;
   bool caseSensitive;
+  bool csv;
+  bool hex;
   bool useGpu;
   bool stopWhenFound;
   bool endOfSearch;

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@ void printUsage() {
   printf("             [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]\n");
   printf("             [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]\n");
   printf("             [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]\n");
-  printf("             [-rp privkey partialkeyfile] [-csv] [prefix]\n\n");
+  printf("             [-rp privkey partialkeyfile] [-csv] [-hex] [prefix]\n\n");
   printf(" prefix: prefix to search (Can contains wildcard '?' or '*')\n");
   printf(" -v: Print version\n");
   printf(" -u: Search uncompressed addresses\n");
@@ -61,6 +61,7 @@ void printUsage() {
   printf(" -sp startPubKey: Start the search with a pubKey (for private key splitting)\n");
   printf(" -r rekey: Rekey interval in MegaKey, default is disabled\n");
   printf(" -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]\n");
+  printf(" -hex: Output of matches in hex only format\n");
   exit(-1);
 
 }
@@ -399,6 +400,7 @@ int main(int argc, char* argv[]) {
   bool startPubKeyCompressed;
   bool caseSensitive = true;
   bool csv = false;
+  bool hex = false;
   bool paranoiacSeed = false;
 
   while (a < argc) {
@@ -418,6 +420,9 @@ int main(int argc, char* argv[]) {
       a++;
     } else if (strcmp(argv[a], "-csv") == 0) {
       csv = true;
+      a++;
+    } else if (strcmp(argv[a], "-hex") == 0) {
+      hex = true;
       a++;
     } else if (strcmp(argv[a], "-v") == 0) {
       printf("%s\n",RELEASE);
@@ -539,7 +544,7 @@ int main(int argc, char* argv[]) {
   }
 
   VanitySearch *v = new VanitySearch(secp, prefix, seed, searchMode, gpuEnable, stop, outputFile, sse,
-    maxFound, rekey, caseSensitive, csv, startPuKey, paranoiacSeed);
+    maxFound, rekey, caseSensitive, csv, hex, startPuKey, paranoiacSeed);
   v->Search(nbCPUThread,gpuId,gridSize);
 
   return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -37,7 +37,7 @@ void printUsage() {
   printf("             [-gpuId gpuId1[,gpuId2,...]] [-g gridSize1[,gridSize2,...]]\n");
   printf("             [-o outputfile] [-m maxFound] [-ps seed] [-s seed] [-t nbThread]\n");
   printf("             [-nosse] [-r rekey] [-check] [-kp] [-sp startPubKey]\n");
-  printf("             [-rp privkey partialkeyfile] [prefix]\n\n");
+  printf("             [-rp privkey partialkeyfile] [-csv] [prefix]\n\n");
   printf(" prefix: prefix to search (Can contains wildcard '?' or '*')\n");
   printf(" -v: Print version\n");
   printf(" -u: Search uncompressed addresses\n");
@@ -60,6 +60,7 @@ void printUsage() {
   printf(" -rp privkey partialkeyfile: Reconstruct final private key(s) from partial key(s) info.\n");
   printf(" -sp startPubKey: Start the search with a pubKey (for private key splitting)\n");
   printf(" -r rekey: Rekey interval in MegaKey, default is disabled\n");
+  printf(" -csv: Output of matches in csv format as [format],[Address],[WIF],[HEX]\n");
   exit(-1);
 
 }
@@ -397,6 +398,7 @@ int main(int argc, char* argv[]) {
   startPuKey.Clear();
   bool startPubKeyCompressed;
   bool caseSensitive = true;
+  bool csv = false;
   bool paranoiacSeed = false;
 
   while (a < argc) {
@@ -413,6 +415,9 @@ int main(int argc, char* argv[]) {
       a++;
     } else if (strcmp(argv[a], "-c") == 0) {
       caseSensitive = false;
+      a++;
+    } else if (strcmp(argv[a], "-csv") == 0) {
+      csv = true;
       a++;
     } else if (strcmp(argv[a], "-v") == 0) {
       printf("%s\n",RELEASE);
@@ -534,7 +539,7 @@ int main(int argc, char* argv[]) {
   }
 
   VanitySearch *v = new VanitySearch(secp, prefix, seed, searchMode, gpuEnable, stop, outputFile, sse,
-    maxFound, rekey, caseSensitive, startPuKey, paranoiacSeed);
+    maxFound, rekey, caseSensitive, csv, startPuKey, paranoiacSeed);
   v->Search(nbCPUThread,gpuId,gridSize);
 
   return 0;


### PR DESCRIPTION
csv output format added '-csv' and '-hex' only output added
-csv: Output of matches in csv format as [format],[Address],[WIF],[HEX] in terminal and in output file.

-hex: output of matches in only in hex.
-hex: Output of matches in hex only format in terminal and in output file.

and can you please make 696 and 731 lines in Vanity.cpp file to show pattern of match by replacing lines with match of pattern. am unable to do.
fprintf(f, "Pattern : %s\n", Patt.c_str());
if you do this result should be: [pattern],[format],[Address],[WIF],[HEX]
1feee,p2pkh,1feeeH4Ku5P8XKW2zpr2RJgtpAL45GQ3P,L2yDGwGoXgg7aJDQJxch4zAXtRtHKYk7V1mi3ES2Egqp7Vmx8Dp7,AB90DABC088D1C888A6A639870E3A192C3AF7E3BDEEC6923291A08B22738054E

Thanks.
