### PR TITLE
Fix FTBFS on gcc 14.2.0 on Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,16 @@ ccap       = $(shell echo $(CCAP) | tr -d '.')
 
 ifdef gpu
 ifdef debug
-CXXFLAGS   = -DWITHGPU -m64  -mssse3 -Wno-write-strings -g -I. -I$(CUDA)/include
+CXXFLAGS   = -DWITHGPU -m64  -mssse3 -Wno-write-strings -g -fno-strict-aliasing -I. -I$(CUDA)/include
 else
-CXXFLAGS   =  -DWITHGPU -m64 -mssse3 -Wno-write-strings -O2 -I. -I$(CUDA)/include
+CXXFLAGS   =  -DWITHGPU -m64 -mssse3 -Wno-write-strings -O2 -fno-strict-aliasing -I. -I$(CUDA)/include
 endif
 LFLAGS     = -lpthread -L$(CUDA)/lib64 -lcudart
 else
 ifdef debug
-CXXFLAGS   = -m64 -mssse3 -Wno-write-strings -g -I. -I$(CUDA)/include
+CXXFLAGS   = -m64 -mssse3 -Wno-write-strings -fno-strict-aliasing -g -I. -I$(CUDA)/include
 else
-CXXFLAGS   =  -m64 -mssse3 -Wno-write-strings -O2 -I. -I$(CUDA)/include
+CXXFLAGS   =  -m64 -mssse3 -Wno-write-strings -O2 -fno-strict-aliasing -I. -I$(CUDA)/include
 endif
 LFLAGS     = -lpthread
 endif

--- a/Timer.h
+++ b/Timer.h
@@ -19,6 +19,7 @@
 #define TIMERH
 
 #include <time.h>
+#include <cstdint>
 #include <string>
 #ifdef WIN64
 #include <windows.h>

--- a/hash/sha256.h
+++ b/hash/sha256.h
@@ -18,6 +18,7 @@
 #ifndef SHA256_H
 #define SHA256_H
 #include <string>
+#include <cstdint>
 
 void sha256(uint8_t *input,int length, uint8_t *digest);
 void sha256_33(uint8_t *input, uint8_t *digest);

--- a/hash/sha512.h
+++ b/hash/sha512.h
@@ -18,6 +18,7 @@
 #ifndef SHA512_H
 #define SHA512_H
 #include <string>
+#include <cstdint>
 
 void sha512(unsigned char *input, int length, unsigned char *digest);
 void pbkdf2_hmac_sha512(uint8_t *out, size_t outlen,const uint8_t *passwd, size_t passlen,const uint8_t *salt, size_t saltlen,uint64_t iter);


### PR DESCRIPTION
It seems that some compilers implicitly adds that include even if could also clash with Boost defines ;-)

Explicitly include <cstdint> to fix build on latest gcc.