### PR TITLE
Fix Undefined Type 'uint32_t' by Including <cstdint>

### DIFF
--- a/Timer.h
+++ b/Timer.h
@@ -20,6 +20,7 @@
 
 #include <time.h>
 #include <string>
+#include <cstdint>
 #ifdef WIN64
 #include <windows.h>
 #endif

--- a/hash/sha256.cpp
+++ b/hash/sha256.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <string.h>
+#include <cstdint>
 #include "sha256.h"
 
 #define BSWAP

--- a/hash/sha256.h
+++ b/hash/sha256.h
@@ -18,6 +18,7 @@
 #ifndef SHA256_H
 #define SHA256_H
 #include <string>
+#include <cstdint>
 
 void sha256(uint8_t *input,int length, uint8_t *digest);
 void sha256_33(uint8_t *input, uint8_t *digest);

--- a/hash/sha512.cpp
+++ b/hash/sha512.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <string.h>
+#include <cstdint>
 #include "sha512.h"
 
 #define BSWAP


### PR DESCRIPTION
The following error occurs when trying to compile. It has been reported by many users:

`$ make`

```
cd obj &&       mkdir -p GPU
cd obj &&       mkdir -p hash
g++ -m64 -mssse3 -Wno-write-strings -O2 -I. -I/usr/local/cuda-8.0/include -o obj/main.o -c main.cpp
In file included from main.cpp:18:
Timer.h:36:10: error: ‘uint32_t’ does not name a type
   36 |   static uint32_t getSeed32();
      |          ^~~~~~~~
Timer.h:23:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   22 | #include <string>
  +++ |+#include <cstdint>
   23 | #ifdef WIN64
Timer.h:37:27: error: ‘uint32_t’ has not been declared
   37 |   static void SleepMillis(uint32_t millis);
      |                           ^~~~~~~~
main.cpp: In function ‘int main(int, char**)’:
main.cpp:372:16: error: ‘getSeed32’ is not a member of ‘Timer’
  372 |   rseed(Timer::getSeed32());
      |                ^~~~~~~~~
```

This happens because the type uint32_t is used, but the corresponding definition is missing. uint32_t is one of the standardized data types defined in <cstdint>.
If this header file is not included, the compiler does not recognize the type and issues the error. This type is defined in the header file <cstdint>. The compiler already suggests including the header file. 

This patch will fix it.