### PR TITLE
Add end time display when search completes

### DIFF
--- a/Vanity.cpp
+++ b/Vanity.cpp
@@ -1764,7 +1764,10 @@ void VanitySearch::Search(int nbThread,std::vector<int> gpuId,std::vector<int> g
     t0 = t1;
 
   }
-
+  char *ctimeBuff;
+  time_t now = time(NULL);
+  ctimeBuff = ctime(&now);
+  printf("End %s", ctimeBuff);
   free(params);
 
 }


### PR DESCRIPTION
This PR adds a timestamp display when a search completes. Previously only the start time was shown at the beginning of a search, now users can see both the start and end times, making it easier to track total search duration. This is particularly useful for benchmarking and for users who want to see exactly how long successful searches take.